### PR TITLE
Replace partial with union including undefined

### DIFF
--- a/src/mutable.ts
+++ b/src/mutable.ts
@@ -4,10 +4,10 @@
 
 export type JsonPrimitive = string | number | boolean | null;
 
-export type JsonObject = Partial<{
-    [key: string]: JsonValue,
-    [key: symbol]: never,
-}>;
+export type JsonObject = {
+    [key: string]: JsonValue|undefined,
+    [key: symbol]: never|undefined,
+};
 
 export type JsonArray = JsonValue[];
 
@@ -19,10 +19,10 @@ export type JsonValue = JsonPrimitive | JsonStructure;
  * Types that can be converted to JSON.
  */
 
-export type JsonCompatibleObject = Partial<{
-    [key: string]: JsonCompatible,
-    [key: symbol]: never,
-}>;
+export type JsonCompatibleObject = {
+    [key: string]: JsonCompatible|undefined,
+    [key: symbol]: never|undefined,
+};
 
 export type JsonCompatibleArray = JsonCompatible[];
 

--- a/src/readonly.ts
+++ b/src/readonly.ts
@@ -4,10 +4,10 @@
 
 import {JsonPrimitive} from './mutable';
 
-export type ReadonlyJsonObject = Partial<{
-    readonly [key: string]: ReadonlyJsonValue,
-    readonly [key: symbol]: never,
-}>;
+export type ReadonlyJsonObject = {
+    readonly [key: string]: ReadonlyJsonValue|undefined,
+    readonly [key: symbol]: never|undefined,
+};
 
 export type ReadonlyJsonArray = readonly ReadonlyJsonValue[];
 
@@ -19,10 +19,10 @@ export type ReadonlyJsonValue = JsonPrimitive | ReadonlyJsonStructure;
  * Types that can be converted to JSON.
  */
 
-export type ReadonlyJsonCompatibleObject = Partial<{
-    readonly [key: string]: ReadonlyJsonCompatible,
-    readonly [key: symbol]: never,
-}>;
+export type ReadonlyJsonCompatibleObject = {
+    readonly [key: string]: ReadonlyJsonCompatible|undefined,
+    readonly [key: symbol]: never|undefined,
+};
 
 export type ReadonlyJsonCompatibleArray = readonly ReadonlyJsonCompatible[];
 

--- a/test/mutable.test-d.ts
+++ b/test/mutable.test-d.ts
@@ -83,6 +83,10 @@ export namespace complex {
     expectAssignable<JsonValue>(type<MappedVariant<'bar'>>());
     expectAssignable<JsonValue>(type<MappedVariant<keyof MappedVariantMap>>());
 
+    type OptionalProperty = {foo?: string};
+
+    expectAssignable<JsonValue>(type<OptionalProperty>());
+
     type MappedVariantWithNonJsonVariantMap = {
         foo: {foo: string},
         bar: {bar: symbol},

--- a/test/mutableCompatible.test-d.ts
+++ b/test/mutableCompatible.test-d.ts
@@ -83,6 +83,10 @@ export namespace complex {
     expectAssignable<JsonCompatible>(type<MappedVariant<'bar'>>());
     expectAssignable<JsonCompatible>(type<MappedVariant<keyof MappedVariantMap>>());
 
+    type OptionalProperty = {foo?: string};
+
+    expectAssignable<JsonCompatible>(type<OptionalProperty>());
+
     type MappedVariantWithNonJsonVariantMap = {
         foo: {foo: string},
         bar: {bar: symbol},

--- a/test/readonly.test-d.ts
+++ b/test/readonly.test-d.ts
@@ -83,6 +83,10 @@ export namespace complex {
     expectAssignable<ReadonlyJsonValue>(type<MappedVariant<'bar'>>());
     expectAssignable<ReadonlyJsonValue>(type<MappedVariant<keyof MappedVariantMap>>());
 
+    type OptionalProperty = {foo?: string};
+
+    expectAssignable<ReadonlyJsonValue>(type<OptionalProperty>());
+
     type MappedVariantWithNonJsonVariantMap = {
         foo: {foo: string},
         bar: {bar: symbol},

--- a/test/readonlyCompatible.test-d.ts
+++ b/test/readonlyCompatible.test-d.ts
@@ -83,6 +83,10 @@ export namespace complex {
     expectAssignable<ReadonlyJsonCompatible>(type<MappedVariant<'bar'>>());
     expectAssignable<ReadonlyJsonCompatible>(type<MappedVariant<keyof MappedVariantMap>>());
 
+    type OptionalProperty = {foo?: string};
+
+    expectAssignable<ReadonlyJsonCompatible>(type<OptionalProperty>());
+
     type MappedVariantWithNonJsonVariantMap = {
         foo: {foo: string},
         bar: {bar: symbol},


### PR DESCRIPTION
## Summary
Using `Partial`, most errors expand the `JsonObject` variants to `Partial<{[key: string]: JsonValue;[key: symbol]: never;}>`, making it hard to grasp. Replacing the `Partial` with unions of `undefined` makes TypeScript preserve the type alias.

Note that TypeScript offers no guarantees about aliases preservation, meaning that it may not work in the future. Still, it is worth the change since it brings upsides for an unforeseen window and no downsides.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings