### PR TITLE
Add re-exports of JSON methods with proper types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,3 @@
-import {JsonValue} from './mutable';
-import {ReadonlyJsonValue} from './readonly';
-
 export * from './mutable';
 export * from './readonly';
-
-export const typeSafeJsonParse: (jsonString: string) => JsonValue = JSON.parse;
-
-export const typedSafeStringify: (jsonValue: ReadonlyJsonValue) => string = JSON.stringify;
+export * from './jsonOperations';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,9 @@
+import {JsonValue} from './mutable';
+import {ReadonlyJsonValue} from './readonly';
+
 export * from './mutable';
 export * from './readonly';
+
+export const typeSafeJsonParse: (jsonString: string) => JsonValue = JSON.parse;
+
+export const typedSafeStringify: (jsonValue: ReadonlyJsonValue) => string = JSON.stringify;

--- a/src/jsonOperations.ts
+++ b/src/jsonOperations.ts
@@ -1,0 +1,6 @@
+import {JsonValue} from './mutable';
+import {ReadonlyJsonValue} from './readonly';
+
+export const typeSafeJsonParse: (jsonString: string) => JsonValue = JSON.parse;
+
+export const typedSafeStringify: (jsonValue: ReadonlyJsonValue) => string = JSON.stringify;


### PR DESCRIPTION
## Summary

Re-export `JSON.parse` and `JSON.stringify` with the types provided by this library.

Using these typed functions avoids the pitfalls of `JSON.parse` returning `any` and accidentally missing validations. For example:

```ts
function takeString(value: string) {}

const value = JSON.parse('123');

// This is accepted by TS
takeString(value);

const typedValue = typeSafeJsonParse('123');

// This is blocked by TS
takeString(typedValue);

if (typeof typedValue === 'string') {
  // Can only be used if properly checked
  takeString(typedValue);
}
```