### PR TITLE
Rename typed methods and relax stringify input

### DIFF
--- a/src/jsonOperations.ts
+++ b/src/jsonOperations.ts
@@ -1,6 +1,6 @@
 import {JsonValue} from './mutable';
-import {ReadonlyJsonValue} from './readonly';
+import {ReadonlyJsonCompatible} from './readonly';
 
-export const typeSafeJsonParse: (jsonString: string) => JsonValue = JSON.parse;
+export const parseJson: (jsonString: string) => JsonValue = JSON.parse;
 
-export const typedSafeStringify: (jsonValue: ReadonlyJsonValue) => string = JSON.stringify;
+export const serializeJson: (jsonValue: ReadonlyJsonCompatible) => string = JSON.stringify;


### PR DESCRIPTION
## Summary

- Rename the exported `JSON` methods to `parseJson` and `serializeJson`.
- Relax the input of `serializeJson` to accept JSON-compatible values.